### PR TITLE
add safe directory

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,11 @@
 FROM python:3.8-slim
 
 RUN apt-get update && apt-get install -y jq zip git
+RUN git config --system --add safe.directory /github/workspace
+
 RUN pip install awscli
 
 ADD entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
+
 ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
Patch to fix error: 

fatal: detected dubious ownership in repository at ‘/github/workspace’ To add an exception for this directory, call: git config --global --add safe.directory /github/workspace